### PR TITLE
feat: add year and view mode selection

### DIFF
--- a/calendar-template.html
+++ b/calendar-template.html
@@ -8,6 +8,7 @@ body{font-family:Arial, sans-serif;}
 #nav{display:flex;justify-content:space-between;align-items:center;max-width:840px;margin:20px auto;font-size:32px;}
 #nav a{text-decoration:none;color:#00f;}
 #title{font-weight:bold;}
+#options{text-align:center;max-width:840px;margin:10px auto;font-size:28px;}
 table.calendar{border-collapse:collapse;margin:0 auto;}
 table.calendar th,table.calendar td{border:1px solid #ccc;width:120px;height:120px;text-align:center;font-size:32px;}
 table.calendar th{background:#eee;}
@@ -24,6 +25,15 @@ table.calendar td.holiday{background:#ffdddd;}
   <span id="title"></span>
   <a id="next" href="#">Next &#62;</a>
 </div>
+<div id="options">
+  View:
+  <select id="mode">
+    <option value="month">Month</option>
+    <option value="year">Year</option>
+  </select>
+  Year:
+  <select id="yearSel"></select>
+</div>
 <table id="cal" class="calendar">
   <thead>
     <tr><th>Sun</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th></tr>
@@ -35,6 +45,8 @@ table.calendar td.holiday{background:#ffdddd;}
 import dayjs from 'https://cdn.jsdelivr.net/npm/dayjs@1.11.8/+esm';
 let cur=dayjs('2025-09-01');
 let holidayMap={};
+const yearSel=document.getElementById('yearSel');
+const modeSel=document.getElementById('mode');
 fetch('hk_holidays_2017_2026.json').then(r=>r.json()).then(data=>{
   if(Array.isArray(data)){
     for(const h of data){
@@ -47,34 +59,61 @@ fetch('hk_holidays_2017_2026.json').then(r=>r.json()).then(data=>{
       }
     }
   }
+  const years=[...new Set(Object.keys(holidayMap).map(d=>d.slice(0,4)))].sort();
+  for(const y of years){
+    const opt=document.createElement('option');
+    opt.value=y; opt.textContent=y;
+    yearSel.appendChild(opt);
+  }
+  yearSel.value=cur.year();
   render();
 });
 function render(){
-  document.getElementById('title').textContent=`Calendar for ${cur.format('MMMM YYYY')} (Hong Kong)`;
+  const mode=modeSel.value;
   const tbody=document.querySelector('#cal tbody');
-  tbody.innerHTML='';
-  const start=cur.startOf('month');
-  let d=start.startOf('week');
-  for(let r=0;r<6;r++){
-    const tr=document.createElement('tr');
-    for(let c=0;c<7;c++){
-      const td=document.createElement('td');
-      if(d.month()!==cur.month()) td.className='noday';
-      else{
-        td.textContent=d.date();
-        const iso=d.format('YYYY-MM-DD');
-        if(d.day()===0) td.classList.add('sun');
-        if(d.day()===6) td.classList.add('sat');
-        if(holidayMap[iso]){td.classList.add('holiday'); td.title=holidayMap[iso];}
-        if(d.isSame(dayjs(),'day')) td.classList.add('today');
+  const cal=document.getElementById('cal');
+  const prevBtn=document.getElementById('prev');
+  const nextBtn=document.getElementById('next');
+  yearSel.value=cur.year();
+  if(mode==='month'){
+    cal.style.display='';
+    prevBtn.style.display='';
+    nextBtn.style.display='';
+    document.getElementById('title').textContent=`Calendar for ${cur.format('MMMM YYYY')} (Hong Kong)`;
+    tbody.innerHTML='';
+    const start=cur.startOf('month');
+    let d=start.startOf('week');
+    for(let r=0;r<6;r++){
+      const tr=document.createElement('tr');
+      for(let c=0;c<7;c++){
+        const td=document.createElement('td');
+        if(d.month()!==cur.month()) td.className='noday';
+        else{
+          td.textContent=d.date();
+          const iso=d.format('YYYY-MM-DD');
+          if(d.day()===0) td.classList.add('sun');
+          if(d.day()===6) td.classList.add('sat');
+          if(holidayMap[iso]){td.classList.add('holiday'); td.title=holidayMap[iso];}
+          if(d.isSame(dayjs(),'day')) td.classList.add('today');
+        }
+        tr.appendChild(td); d=d.add(1,'day');
       }
-      tr.appendChild(td); d=d.add(1,'day');
+      tbody.appendChild(tr);
     }
-    tbody.appendChild(tr);
+    const monthHols=Object.entries(holidayMap).filter(([k])=>k.startsWith(cur.format('YYYY-MM')));
+    document.getElementById('holidays').innerHTML=monthHols.map(([d,name])=>`<div>${d}: ${name}</div>`).join('');
+  }else{
+    cal.style.display='none';
+    prevBtn.style.display='none';
+    nextBtn.style.display='none';
+    document.getElementById('title').textContent=`Holidays for ${cur.year()} (Hong Kong)`;
+    tbody.innerHTML='';
+    const yearHols=Object.entries(holidayMap).filter(([k])=>k.startsWith(cur.format('YYYY'))).sort((a,b)=>a[0].localeCompare(b[0]));
+    document.getElementById('holidays').innerHTML=yearHols.map(([d,name])=>`<div>${d} (${dayjs(d).format('dddd')}): ${name}</div>`).join('');
   }
-  const monthHols=Object.entries(holidayMap).filter(([k])=>k.startsWith(cur.format('YYYY-MM')));
-  document.getElementById('holidays').innerHTML=monthHols.map(([d,name])=>`<div>${d}: ${name}</div>`).join('');
 }
+yearSel.onchange=()=>{cur=cur.year(parseInt(yearSel.value,10));render();};
+modeSel.onchange=render;
 prev.onclick=e=>{e.preventDefault();cur=cur.subtract(1,'month');render();};
 next.onclick=e=>{e.preventDefault();cur=cur.add(1,'month');render();};
 </script>


### PR DESCRIPTION
## Summary
- allow switching between month and year views with a new mode selector
- add year dropdown and full-year holiday listing with weekday labels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb96d18f4c8332a3092b40fe258ec6