### PR TITLE
Resize monthly calendar cells to match yearly view

### DIFF
--- a/calendar-template.html
+++ b/calendar-template.html
@@ -10,7 +10,7 @@ body{font-family:Arial, sans-serif;}
 #title{font-weight:bold;}
 #options{text-align:center;max-width:840px;margin:10px auto;font-size:28px;}
 table.calendar{border-collapse:collapse;margin:0 auto;}
-table.calendar th,table.calendar td{border:1px solid #ccc;width:120px;height:120px;text-align:center;font-size:32px;}
+table.calendar th,table.calendar td{border:1px solid #ccc;width:40px;height:40px;text-align:center;font-size:14px;}
 table.calendar th{background:#eee;}
 table.calendar td.sun{color:#b30000;}
 table.calendar td.sat{color:#555;}


### PR DESCRIPTION
## Summary
- match monthly calendar cell dimensions with yearly view by shrinking cells to 40×40 and reducing font size

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ea2cd348332b07ec74cd82067d6