### PR TITLE
Simplify weekday labels and show weekdays in monthly list

### DIFF
--- a/calendar-template.html
+++ b/calendar-template.html
@@ -64,7 +64,7 @@ let holidayMap={};
 const yearSel=document.getElementById('yearSel');
 const modeSel=document.getElementById('mode');
 const langSel=document.getElementById('langSel');
-const DOW_ZH=['周日','周一','周二','周三','周四','周五','周六'];
+const DOW_ZH=['日','一','二','三','四','五','六'];
 const DOW_EN=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 const DOW_EN_FULL=['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
 fetch('hk_holidays_2017_2026.json').then(r=>r.json()).then(data=>{
@@ -127,8 +127,12 @@ function render(){
       }
       tbody.appendChild(tr);
     }
-    const monthHols=Object.entries(holidayMap).filter(([k])=>k.startsWith(cur.format('YYYY-MM')));
-    document.getElementById('holidays').innerHTML=monthHols.map(([d,n])=>`<div>${d}: ${n[lang]}</div>`).join('');
+    const monthHols=Object.entries(holidayMap)
+      .filter(([k])=>k.startsWith(cur.format('YYYY-MM')))
+      .sort((a,b)=>a[0].localeCompare(b[0]));
+    document.getElementById('holidays').innerHTML=monthHols
+      .map(([d,n])=>`<div>${d} (${dowFull[dayjs(d).day()]}): ${n[lang]}</div>`)
+      .join('');
   }else{
     cal.style.display='none';
     yearCal.style.display='flex';


### PR DESCRIPTION
## Summary
- Use single-character Chinese weekday headers
- Display weekday in monthly holiday list

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd826f4b7c8332971fc00816769a86