### PR TITLE
Remove warning emoji from fetch script

### DIFF
--- a/scripts/fetch_company_holidays.mjs
+++ b/scripts/fetch_company_holidays.mjs
@@ -32,7 +32,7 @@ async function fetchJson(urls) {
       const res = await fetch(url);
       if (res.ok) return await res.json();
     } catch (e) {
-      console.warn(`⚠️  Failed to fetch ${url}: ${e.message}`);
+      console.warn(`Failed to fetch ${url}: ${e.message}`);
     }
   }
   return null;
@@ -45,7 +45,7 @@ async function fetchHtml(urls) {
       const res = await fetch(url);
       if (res.ok) return await res.text();
     } catch (e) {
-      console.warn(`⚠️  Failed to fetch ${url}: ${e.message}`);
+      console.warn(`Failed to fetch ${url}: ${e.message}`);
     }
   }
   return '';


### PR DESCRIPTION
## Summary
- remove redundant warning emoji from `fetch_company_holidays.mjs`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7fb26ac48332911f2e4253702b63