### PR TITLE
Fix output paths for holiday fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,15 @@
 - `hk_holidays_2017_2026.json` — 假期資料（2017–2026）
 - `generate.js` — Node.js 抓取假期原始來源並生成 JSON
 
+## Fetching holiday data
+
+```
+npm run fetch:holidays
+```
+
+上述指令會從 1823 等來源下載最新公司假期資料，
+並把 JSON 檔寫入 `data/`，驗證報告寫入 `reports/`。
+這兩個資料夾都設為 `.gitignore`，檔案不會被提交到版本控制中。
+
 ---
 © 2025 raymondckm2000 — Demo project for HK holiday data

--- a/scripts/fetch_company_holidays.mjs
+++ b/scripts/fetch_company_holidays.mjs
@@ -1,13 +1,16 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { load } from 'cheerio';
 import dns from 'node:dns';
 
 // Prefer IPv4 (1823 blocks IPv6 in some environments)
 try { dns.setDefaultResultOrder('ipv4first'); } catch {}
 
-const DATA_DIR = path.resolve('data');
-const REPORT_DIR = path.resolve('reports');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const DATA_DIR = path.join(ROOT_DIR, 'data');
+const REPORT_DIR = path.join(ROOT_DIR, 'reports');
 fs.mkdirSync(DATA_DIR, { recursive: true });
 fs.mkdirSync(REPORT_DIR, { recursive: true });
 
@@ -32,7 +35,7 @@ async function fetchJson(urls) {
       const res = await fetch(url);
       if (res.ok) return await res.json();
     } catch (e) {
-      console.warn(`⚠️  Failed to fetch ${url}: ${e.message}`);
+      console.warn(`Failed to fetch ${url}: ${e.message}`);
     }
   }
   return null;
@@ -45,7 +48,7 @@ async function fetchHtml(urls) {
       const res = await fetch(url);
       if (res.ok) return await res.text();
     } catch (e) {
-      console.warn(`⚠️  Failed to fetch ${url}: ${e.message}`);
+      console.warn(`Failed to fetch ${url}: ${e.message}`);
     }
   }
   return '';


### PR DESCRIPTION
## Summary
- ensure fetch script resolves `data/` and `reports/` directories relative to repo root
- document holiday data fetching steps and output locations in README

## Testing
- `npm run fetch:holidays` *(fails: fetch failed; Done. 0 records.)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7fb26ac48332911f2e4253702b63