### PR TITLE
Expand holiday fetch for recurring events

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cheerio": "^1.1.2",
     "dayjs": "^1.11.18",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "rrule": "^2.8.1"
   }
 }


### PR DESCRIPTION
## Summary
- expand company holiday fetch to handle recurring events via rrule
- add rrule dependency for recurrence parsing

## Testing
- `npm install` *(fails: 403 Forbidden to fetch rrule)*
- `npm test`
- `node scripts/fetch_company_holidays.mjs` *(fails: Cannot find package 'rrule')*


------
https://chatgpt.com/codex/tasks/task_e_68bfa16937c08332bfb32fbad881db62